### PR TITLE
feat: Release templating support in mock server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@requestly/mock-server",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@requestly/mock-server",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@requestly/mock-server",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "- Methods: GET, POST, PUT, OPTIONS - Description - Endpoint (can be full path) (/api/v1/users) - Multiple Responses     - Shuffle Response     - Sequential Response     - Rules in Response - Status (Any status code 2xx, 4xx) - Latency - Body     - Templating     - Faker js - Headers",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "npm run build && node build/test/index.js",
     "start:dev": "npx nodemon",
-    "build": "rimraf ./build && tsc"
+    "build": "rimraf ./build && tsc",
+    "prepack": "npm run build"
   },
   "author": "",
   "license": "ISC",

--- a/src/core/common/mockProcessor.ts
+++ b/src/core/common/mockProcessor.ts
@@ -64,20 +64,14 @@ class MockProcessor {
   };
 
   // TODO: Pass extra params here required for rendering
-  // TODO: Do template rendering here
   static renderBody = (
     responseTemplate: Response,
     mockContextParams: MockContextParams
   ) => {
     let finalBody = null;
     let bodyTemplate: string = responseTemplate.body;
-    return bodyTemplate;
-    /**
-     * Commenting Templating for now due to a bug
-     * https://linear.app/requestly/issue/ENGG-1804
-     */
-    // finalBody = renderTemplate(bodyTemplate, mockContextParams);
-    // return finalBody;
+    finalBody = renderTemplate(bodyTemplate, mockContextParams);
+    return finalBody;
   };
 
   // Time in ms

--- a/src/core/utils/templating/helpers/requestHelpers.ts
+++ b/src/core/utils/templating/helpers/requestHelpers.ts
@@ -22,7 +22,7 @@ const requestHelpers = (params: MockContextParams) => {
         return defaultValue
       }
 
-      return params.headers[param] || defaultValue;
+      return params.headers[param?.toLowerCase()] || defaultValue;
     },
   };
   return helpers;

--- a/src/test/dummy/mock1.ts
+++ b/src/test/dummy/mock1.ts
@@ -62,6 +62,27 @@ export const dummyMock3: Mock = {
     ]
 }
 
+export const dummyMock4: Mock = {
+    id: "4",
+    desc: "Mock 4 : Password protected",
+    method: RequestMethod.GET,
+    endpoint: "users4/:id/:name",
+    responses: [
+        {
+            id: "1",
+            desc: "Mock 4 Response 1",
+            latency: 0,
+            statusCode: 200,
+            headers: {
+                "x-foo": "bar",
+                "content-type": "text/plain",
+            },
+            body: `the id is {{urlParam 'id'}} . the url is {{url}} . not passing param to url param {{urlParam}}. Content type is  {{header 'Content-Type'}}. giberish ahead: {{random values}} {{}} {{color: "something"}} {{url 'http://localhost:3000'}} {{urlParam 'id'}} {{ color: "red", display: flex}}`
+        }
+    ]
+
+}
+
 export const getSelectorMap = (): any => {
     let selectorMap: any = {}
     selectorMap[dummyMock1.id] = {
@@ -77,6 +98,11 @@ export const getSelectorMap = (): any => {
     selectorMap[dummyMock3.id] = {
         method: dummyMock3.method,
         endpoint: dummyMock3.endpoint
+    };
+
+    selectorMap[dummyMock4.id] = {
+        method: dummyMock4.method,
+        endpoint: dummyMock4.endpoint
     };
 
     return selectorMap;

--- a/src/test/firebaseConfigFetcher.ts
+++ b/src/test/firebaseConfigFetcher.ts
@@ -1,4 +1,4 @@
-import { dummyMock1, dummyMock2, dummyMock3, getSelectorMap } from "./dummy/mock1";
+import { dummyMock1, dummyMock2, dummyMock3, dummyMock4, getSelectorMap } from "./dummy/mock1";
 import IConfigFetcher from "../interfaces/configFetcherInterface";
 
 
@@ -17,6 +17,9 @@ class FirebaseConfigFetcher implements IConfigFetcher {
         }
         else if(id === "3") {
             return dummyMock3;
+        }
+        else if(id === "4") {
+            return dummyMock4;
         }
 
         return null;


### PR DESCRIPTION
changes in https://github.com/requestly/requestly-mock-server/pull/17 fix the issue that caused the revert in https://github.com/requestly/requestly-mock-server/pull/14 
hence its now safe to release it back.

P.S. _Also adds a `prepack` script to avoid forgetting to build before publish_ 😓