### PR TITLE
Refactor: Exposed MockServer config [BREAKING CHANGE]

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ npm i @requestly/mock-server
 ``` javascript
 import * as functions from 'firebase-functions';
 import { MockServer } from '@requestly/mock-server';
-import firebaseConfigFetcher from '../firebaseConfigFetcher';
+import firebaseConfig from '../firebaseConfig';
 
 const startMockServer = () => {
-  const expressApp = new MockServer(3000, firebaseConfigFetcher, '/api/mockv2').app;
+  const expressApp = new MockServer(3000, firebaseConfig, '/api/mockv2').app;
 
   return functions.runWith({ minInstances: isProdEnv() ? 1 : 0 }).https.onRequest(expressApp);
 };
@@ -36,7 +36,7 @@ export const handleMockRequest = startMockServer();
 ```
 
 ``` javascript
-class FirebaseConfigFetcher implements IConfigFetcher {
+class FirebaseConfig implements IConfig {
     getMockSelectorMap = (kwargs?: any) => {
         /**
         * Fetch and return mockSelectorMap from firestore
@@ -54,10 +54,16 @@ class FirebaseConfigFetcher implements IConfigFetcher {
         * Fetch mock details from firestore
         */
     }
+
+    storeLog? = (log: Log) => {
+        /**
+        * Store log in cloud storages
+        */
+    }
 }
 
-const firebaseConfigFetcher = new FirebaseConfigFetcher();
-export default firebaseConfigFetcher;
+const firebaseConfig = new FirebaseConfig();
+export default firebaseConfig;
 ```
 
 
@@ -69,9 +75,9 @@ export default firebaseConfigFetcher;
 1. Request coming from GET `https://username.requestly.dev/users`
 2. Firebase Function passes the request to @requestly/mock-server
 3. @requestly/mock-server - MockSelector
-   a. Fetches all the available mocks using `IConfigFetcher.getMockSelectorMap()` (Firestore in case of Requestly)
+   a. Fetches all the available mocks using `IConfig.getMockSelectorMap()` (Firestore in case of Requestly)
    b. Select mock if any endpoint+method matches the incoming request (GET /users)
-   c. Fetch Mock using `IConfigFetcher.getMock(mockId)` and pass it to MockProcessor
+   c. Fetch Mock using `IConfig.getMock(mockId)` and pass it to MockProcessor
 4. @requestly/mock-server - MockProcessor
    a. Process Mock - Response Rendering
    b. Return Response

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -2,7 +2,7 @@ import express, { Request, Response, Express } from "express";
 import cors from "cors";
 
 import MockServerHandler from "./common/mockHandler";
-import IConfig from "../interfaces/config";
+import { IConfig } from "../interfaces/config";
 import storageService from "../services/storageService";
 import { MockServerResponse } from "../types";
 import { HarMiddleware } from "../middlewares/har";

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -2,10 +2,9 @@ import express, { Request, Response, Express } from "express";
 import cors from "cors";
 
 import MockServerHandler from "./common/mockHandler";
-import IConfigFetcher from "../interfaces/configFetcherInterface";
+import IConfig from "../interfaces/config";
 import storageService from "../services/storageService";
 import { MockServerResponse } from "../types";
-import ILogSink from "../interfaces/logSinkInterface";
 import { HarMiddleware } from "../middlewares/har";
 import { cleanupPath } from "./utils";
 
@@ -15,25 +14,23 @@ interface MockServerConfig {
 }
 
 class MockServer {
-    config: MockServerConfig;
-    configFetcher: IConfigFetcher;
-    logSink: ILogSink;
+    mockConfig: MockServerConfig;
+    config: IConfig;
     app: Express
 
-    constructor (port: number = 3000, configFetcher: IConfigFetcher, logSink: ILogSink, pathPrefix: string = "") {
-        this.config = {
+    constructor (port: number = 3000, config: IConfig, pathPrefix: string = "") {
+        this.mockConfig = {
             port,
             pathPrefix
         };
-        this.configFetcher = configFetcher;
-        this.logSink = logSink;
+        this.config = config;
 
         this.app = this.setup();
     }
 
     start = () => {
-        this.app.listen(this.config.port, () => {
-            console.log(`Mock Server Listening on port ${this.config.port}`);
+        this.app.listen(this.mockConfig.port, () => {
+            console.log(`Mock Server Listening on port ${this.mockConfig.port}`);
         })
     }
 
@@ -66,17 +63,17 @@ class MockServer {
         }));
     
         // pathPrefix to handle /mockv2 prefix in cloud functions
-        const regex = new RegExp(`${this.config.pathPrefix}\/(.+)`);
+        const regex = new RegExp(`${this.mockConfig.pathPrefix}\/(.+)`);
         app.all(regex, async (req: Request, res: Response) => {
             console.log(`Initial Request`);
             console.log(`Path: ${req.path}`);
             console.log(`Query Params: ${JSON.stringify(req.query)}`);
     
             // Stripping URL prefix
-            if(req.path.indexOf(this.config.pathPrefix) === 0) {
-                console.log(`Stripping pathPrefix: ${this.config.pathPrefix}`);
+            if(req.path.indexOf(this.mockConfig.pathPrefix) === 0) {
+                console.log(`Stripping pathPrefix: ${this.mockConfig.pathPrefix}`);
                 Object.defineProperty(req, 'path', {
-                    value: cleanupPath(req.path.slice(this.config.pathPrefix.length)),
+                    value: cleanupPath(req.path.slice(this.mockConfig.pathPrefix.length)),
                     writable: true
                 });
                 console.log(`Path after stripping prefix and cleanup: ${req.path}`);
@@ -93,8 +90,7 @@ class MockServer {
     }
 
     initStorageService = () => {
-        storageService.setConfigFetcher(this.configFetcher);
-        storageService.setLogSink(this.logSink);
+        storageService.setConfig(this.config);
     }
 }
 

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -18,7 +18,7 @@ class MockServer {
     config: IConfig;
     app: Express
 
-    constructor (port: number = 3000, config: IConfig, pathPrefix: string = "") {
+    constructor (config: IConfig, port: number = 3000, pathPrefix: string = "") {
         this.mockConfig = {
             port,
             pathPrefix

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,10 @@
-import IConfigFetcher from "./interfaces/configFetcherInterface";
-import IlogSink from "./interfaces/logSinkInterface";
+import IConfig from "./interfaces/config";
 import MockServer from "./core/server";
 import { Mock as MockSchema, MockMetadata as MockMetadataSchema, Response as MockResponseSchema } from "./types/mock";
 
 export {
     MockServer,
-    IConfigFetcher,
-    IlogSink,
+    IConfig,
     MockSchema,
     MockMetadataSchema,
     MockResponseSchema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
-import IConfig from "./interfaces/config";
+import {IConfig, ISink, ISource} from "./interfaces/config";
 import MockServer from "./core/server";
 import { Mock as MockSchema, MockMetadata as MockMetadataSchema, Response as MockResponseSchema } from "./types/mock";
 
 export {
     MockServer,
-    IConfig,
+    IConfig, ISink, ISource,
     MockSchema,
     MockMetadataSchema,
     MockResponseSchema,

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -1,17 +1,27 @@
+
+
 import { Log } from "../types";
-import { Mock } from "../types/mock";
 
-class IConfig {
+export class ISink {
+    /**
+     * specify how and where to store logs from mock execution
+     */
+    storeLog = (log: Log): Promise<void> => {
+        return Promise.resolve();
+    }
+}
 
+
+import { Mock } from "../types/mock"
+
+export class ISource {
     /**
      * 
      * @param id Mock Id
      * @param kwargs Contains extra val required for storage fetching. Eg. uid in case of firebaseStorageService
      * @returns Return the Mock definition
      */
-    getMock = (id: string, kwargs?: any): Mock | null => {
-        return null
-    }
+    getMock = (id: string, kwargs?: any): Mock | null =>  {return null}
     
 
     /**
@@ -26,18 +36,11 @@ class IConfig {
      *      }
      * }
      */
-    getMockSelectorMap = (kwargs?: any): any => {
-        return {}
-    }
-
-    /**
-     * specify how and where to store logs from mock execution
-     */
-
-    storeLog? = async (log: Log): Promise<void> => {
-        return;
-    }
+    getMockSelectorMap = (kwargs?: any): any => {return {}}
 }
 
 
-export default IConfig;
+export interface IConfig {
+    src: ISource;
+    sink: ISink;
+}

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -40,12 +40,7 @@ export class ISource {
 }
 
 
-export class IConfig {
+export interface IConfig {
     src: ISource;
     sink?: ISink;
-
-    constructor(src: ISource, sink?: ISink) {
-        this.src = src;
-        this.sink = sink;
-    }
 }

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -40,7 +40,12 @@ export class ISource {
 }
 
 
-export interface IConfig {
+export class IConfig {
     src: ISource;
-    sink: ISink;
+    sink?: ISink;
+
+    constructor(src: ISource, sink?: ISink) {
+        this.src = src;
+        this.sink = sink;
+    }
 }

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -1,6 +1,7 @@
+import { Log } from "../types";
 import { Mock } from "../types/mock";
 
-class IConfigFetcher {
+class IConfig {
 
     /**
      * 
@@ -28,6 +29,15 @@ class IConfigFetcher {
     getMockSelectorMap = (kwargs?: any): any => {
         return {}
     }
+
+    /**
+     * specify how and where to store logs from mock execution
+     */
+
+    storeLog? = async (log: Log): Promise<void> => {
+        return;
+    }
 }
 
-export default IConfigFetcher;
+
+export default IConfig;

--- a/src/interfaces/logSinkInterface.ts
+++ b/src/interfaces/logSinkInterface.ts
@@ -1,9 +1,0 @@
-import { Log } from "../types";
-
-class ILogSink {
-    store = async (log: Log): Promise<void> => {
-        return;
-    }
-}
-
-export default ILogSink;

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -1,35 +1,29 @@
-import IConfigFetcher from "../interfaces/configFetcherInterface";
+import IConfig from "../interfaces/config";
 import ILogSink from "../interfaces/logSinkInterface";
 import { Log } from "../types";
 
 class StorageService {
-    configFetcher ?: IConfigFetcher|null = null;
-    logSink ?: ILogSink|null = null;
+    config ?: IConfig|null = null;
 
-    constructor(configFetcher ?: IConfigFetcher, logSink ?: ILogSink) {
-        this.configFetcher = configFetcher;
-        this.logSink = logSink;
+    constructor(config ?: IConfig, logSink ?: ILogSink) {
+        this.config = config;
     }
 
     // TODO: This should be set when starting the mock server
-    setConfigFetcher = (configFetcher: IConfigFetcher) => {
-        this.configFetcher = configFetcher;
-    }
-
-    setLogSink(logSink: ILogSink) {
-        this.logSink = logSink;
+    setConfig = (config: IConfig) => {
+        this.config = config;
     }
 
     getMockSelectorMap = async (kwargs ?: any): Promise<any> => {
-        return this.configFetcher?.getMockSelectorMap(kwargs);
+        return this.config?.getMockSelectorMap(kwargs);
     };
 
     getMock = async (id: string, kwargs?: any): Promise<any> => {
-        return this.configFetcher?.getMock(id, kwargs);
+        return this.config?.getMock(id, kwargs);
     }
 
     storeLog = async (log: Log): Promise<void> => {
-        await this.logSink?.store(log);
+        await this.config?.storeLog?.(log);
     }
 }
 

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -1,11 +1,10 @@
-import IConfig from "../interfaces/config";
-import ILogSink from "../interfaces/logSinkInterface";
+import {IConfig} from "../interfaces/config";
 import { Log } from "../types";
 
 class StorageService {
-    config ?: IConfig|null = null;
+    config?: IConfig | null = null;
 
-    constructor(config ?: IConfig, logSink ?: ILogSink) {
+    constructor(config?: IConfig) {
         this.config = config;
     }
 
@@ -15,15 +14,15 @@ class StorageService {
     }
 
     getMockSelectorMap = async (kwargs ?: any): Promise<any> => {
-        return this.config?.getMockSelectorMap(kwargs);
+        return this.config?.src.getMockSelectorMap(kwargs);
     };
 
     getMock = async (id: string, kwargs?: any): Promise<any> => {
-        return this.config?.getMock(id, kwargs);
+        return this.config?.src.getMock(id, kwargs);
     }
 
     storeLog = async (log: Log): Promise<void> => {
-        await this.config?.storeLog?.(log);
+        await this.config?.sink?.storeLog(log);
     }
 }
 

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -1,28 +1,31 @@
-import {IConfig} from "../interfaces/config";
+import {IConfig, ISink, ISource} from "../interfaces/config";
 import { Log } from "../types";
 
 class StorageService {
-    config?: IConfig | null = null;
+    src: ISource | null = null;
+    sink: ISink | null = null;
 
     constructor(config?: IConfig) {
-        this.config = config;
+        this.src = config?.src || null;
+        this.sink = config?.sink || null;
     }
 
     // TODO: This should be set when starting the mock server
     setConfig = (config: IConfig) => {
-        this.config = config;
+        this.src = config.src || null;
+        this.sink = config.sink || null;
     }
 
     getMockSelectorMap = async (kwargs ?: any): Promise<any> => {
-        return this.config?.src.getMockSelectorMap(kwargs);
+        return this.src?.getMockSelectorMap(kwargs);
     };
 
     getMock = async (id: string, kwargs?: any): Promise<any> => {
-        return this.config?.src.getMock(id, kwargs);
+        return this.src?.getMock(id, kwargs);
     }
 
     storeLog = async (log: Log): Promise<void> => {
-        await this.config?.sink?.storeLog(log);
+        await this.sink?.storeLog(log);
     }
 }
 

--- a/src/test/dummy/FileLogSink.ts
+++ b/src/test/dummy/FileLogSink.ts
@@ -1,11 +1,11 @@
 import fs from 'fs';
 
-import ILogSink from "../interfaces/logSinkInterface";
-import { Log } from "../types";
+import { ISink } from "../../interfaces/config";
+import { Log } from "../../types";
 
 
-class FileLogSink implements ILogSink {
-    store = async (log: Log): Promise<void> => {
+export class FileLogSink implements ISink {
+    storeLog = async (log: Log): Promise<void> => {
         const logLine = `${JSON.stringify(log.HarEntry)}\n`;
         fs.writeFile(`${log.mockId}.log`, logLine, { flag: 'a+' }, (err) => {
             if(err) {
@@ -13,9 +13,5 @@ class FileLogSink implements ILogSink {
                 throw err;
             }
         });
-        Promise.resolve();
     }
 }
-
-const fileLogSink = new FileLogSink();
-export default fileLogSink;

--- a/src/test/dummy/dummySource.ts
+++ b/src/test/dummy/dummySource.ts
@@ -1,0 +1,25 @@
+import { dummyMock1, dummyMock2, dummyMock3, dummyMock4, getSelectorMap } from "./mock1";
+import { ISource } from "../../interfaces/config";
+
+export class DummySource implements ISource {
+    getMockSelectorMap = (kwargs?: any) => {
+        return getSelectorMap();
+    };
+    
+    getMock = (id: string, kwargs?: any) => {
+        if(id === "1") {
+            return dummyMock1;
+        }
+        else if(id === "2") {
+            return dummyMock2;
+        }
+        else if(id === "3") {
+            return dummyMock3;
+        }
+        else if(id === "4") {
+            return dummyMock4;
+        }
+
+        return null;
+    }
+}

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,6 +1,6 @@
 import MockServer from "../core/server";
 import TestConfig from "./testConfig";
 
-const server = new MockServer(3001, TestConfig, "/mocksv2");
+const server = new MockServer(TestConfig, 3001, "/mocksv2");
 console.debug(server.app);
 server.start();

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,7 +1,6 @@
 import MockServer from "../core/server";
-import firebaseConfigFetcher from "./firebaseConfigFetcher";
-import fileLogSink from "./FileLogSink";
+import TestConfig from "./testConfig";
 
-const server = new MockServer(3001, firebaseConfigFetcher, fileLogSink, "/mocksv2");
+const server = new MockServer(3001, TestConfig, "/mocksv2");
 console.debug(server.app);
 server.start();

--- a/src/test/testConfig.ts
+++ b/src/test/testConfig.ts
@@ -3,6 +3,9 @@ import { IConfig } from "../interfaces/config";
 import { DummySource } from "./dummy/dummySource";
 import { FileLogSink } from "./dummy/FileLogSink";
 
-const testConfig = new IConfig(new DummySource(), new FileLogSink());
+const testConfig: IConfig = {
+    src: new DummySource(),
+    sink: new FileLogSink(),
+}
 export default testConfig;
 

--- a/src/test/testConfig.ts
+++ b/src/test/testConfig.ts
@@ -3,9 +3,6 @@ import { IConfig } from "../interfaces/config";
 import { DummySource } from "./dummy/dummySource";
 import { FileLogSink } from "./dummy/FileLogSink";
 
-const testConfig: IConfig = {
-    src: new DummySource(),
-    sink: new FileLogSink()
-};
+const testConfig = new IConfig(new DummySource(), new FileLogSink());
 export default testConfig;
 

--- a/src/test/testConfig.ts
+++ b/src/test/testConfig.ts
@@ -1,9 +1,12 @@
 import { dummyMock1, dummyMock2, dummyMock3, dummyMock4, getSelectorMap } from "./dummy/mock1";
-import IConfigFetcher from "../interfaces/configFetcherInterface";
+import IConfig from "../interfaces/config";
+import { Log } from "../types";
+import fs from 'fs';
+
 
 
 // TODO: Fetch from Firestore and return
-class FirebaseConfigFetcher implements IConfigFetcher {
+class TestConfig implements IConfig {
     getMockSelectorMap = (kwargs?: any) => {
         return getSelectorMap();
     };
@@ -24,7 +27,19 @@ class FirebaseConfigFetcher implements IConfigFetcher {
 
         return null;
     }
+
+    // file log store
+    storeLog = async (log: Log): Promise<void> => {
+        const logLine = `${JSON.stringify(log.HarEntry)}\n`;
+        fs.writeFile(`${log.mockId}.log`, logLine, { flag: 'a+' }, (err) => {
+            if(err) {
+                console.log("Error dumping log to file.");
+                throw err;
+            }
+        });
+        Promise.resolve();
+    }
 }
 
-const firebaseConfigFetcher = new FirebaseConfigFetcher();
-export default firebaseConfigFetcher;
+const testConfig = new TestConfig();
+export default testConfig;

--- a/src/test/testConfig.ts
+++ b/src/test/testConfig.ts
@@ -1,45 +1,11 @@
-import { dummyMock1, dummyMock2, dummyMock3, dummyMock4, getSelectorMap } from "./dummy/mock1";
-import IConfig from "../interfaces/config";
-import { Log } from "../types";
-import fs from 'fs';
 
+import { IConfig } from "../interfaces/config";
+import { DummySource } from "./dummy/dummySource";
+import { FileLogSink } from "./dummy/FileLogSink";
 
-
-// TODO: Fetch from Firestore and return
-class TestConfig implements IConfig {
-    getMockSelectorMap = (kwargs?: any) => {
-        return getSelectorMap();
-    };
-    
-    getMock = (id: string, kwargs?: any) => {
-        if(id === "1") {
-            return dummyMock1;
-        }
-        else if(id === "2") {
-            return dummyMock2;
-        }
-        else if(id === "3") {
-            return dummyMock3;
-        }
-        else if(id === "4") {
-            return dummyMock4;
-        }
-
-        return null;
-    }
-
-    // file log store
-    storeLog = async (log: Log): Promise<void> => {
-        const logLine = `${JSON.stringify(log.HarEntry)}\n`;
-        fs.writeFile(`${log.mockId}.log`, logLine, { flag: 'a+' }, (err) => {
-            if(err) {
-                console.log("Error dumping log to file.");
-                throw err;
-            }
-        });
-        Promise.resolve();
-    }
-}
-
-const testConfig = new TestConfig();
+const testConfig: IConfig = {
+    src: new DummySource(),
+    sink: new FileLogSink()
+};
 export default testConfig;
+


### PR DESCRIPTION
- moves port to be second argument _since it has a default value_
- eliminates the need for `ILogSink` as the log function can be part of the original config object after small renaming in the code (`ConfigFetcher` -> `Config`)