### PR TITLE
chore: version bump to v0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@requestly/mock-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@requestly/mock-server",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "ISC",
       "dependencies": {
         "@types/har-format": "^1.2.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@requestly/mock-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "- Methods: GET, POST, PUT, OPTIONS - Description - Endpoint (can be full path) (/api/v1/users) - Multiple Responses     - Shuffle Response     - Sequential Response     - Rules in Response - Status (Any status code 2xx, 4xx) - Latency - Body     - Templating     - Faker js - Headers",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
missed build step when publishing https://github.com/requestly/requestly-mock-server/pull/26