### PR TITLE
fix: add validations and processing logics to renderTemplate

### DIFF
--- a/src/core/utils/templating/helpers/requestHelpers.ts
+++ b/src/core/utils/templating/helpers/requestHelpers.ts
@@ -2,7 +2,9 @@ import { MockContextParams } from "../../../../types/internal";
 
 const requestHelpers = (params: MockContextParams) => {
   const helpers = {
-    urlParam: (param: string) => params.urlParams[param],
+    urlParams: (param: string) => {
+      return params.urlParams[param]
+    },
     method: () => params.method,
     statusCode: () => params.statusCode,
     header: (param: string, defaultValue: string = '') => {

--- a/src/test/dummy/mock1.ts
+++ b/src/test/dummy/mock1.ts
@@ -85,7 +85,7 @@ export const dummyMock4: Mock = {
         "x-foo": "bar",
         "content-type": "text/plain",
       },
-      body: `the id is {{urlParam 'id'}} . the url is {{url}} . not passing param to url param {{urlParam}}. Content type is  {{header 'Content-Type'}}. giberish ahead: {{random values}} {{}} {{color: "something"}} {{url 'http://localhost:3000'}} {{urlParam 'id'}} {{ color: "red", display: flex}}`,
+      body: `the id is {{urlParams}} {{urlParams id}} no way to add space right now so {{urlParams 'name'}} . the url is {{url}} . not passing param to url param {{urlParam}}. Content type is  {{header Content-Type}}. giberish ahead: {{random values}} {{}} {{color: "something"}} {{url 'http://localhost:3000'}} {{urlParam 'id'}} {{ color: "red", display: flex}}`,
     },
   ],
 };


### PR DESCRIPTION
- validate that params are present for helpers that require params
- validate if the number of params present are equal to or greater than the minimum that are required
- if any of the validations above fail, then escape this part of the template (i.e. not process as helper)
- add quotes if not already added around the args for the helper functions (required in the syntax for specifying them in hbsTemplate


also renames the helper `urlParam` to `urlParams`