### PR TITLE
[ENGG-4251] feat: index request body via template strings

### DIFF
--- a/src/core/common/mockProcessor.ts
+++ b/src/core/common/mockProcessor.ts
@@ -7,6 +7,7 @@ import { validatePassword } from "../utils/mockProcessor";
 import { getServerMockResponse } from "../utils/mockServerResponseHelper";
 import pathMatcher from "../utils/pathMatcher";
 import { renderTemplate } from "../utils/templating";
+import { getPostData } from "../utils/harFormatter";
 
 class MockProcessor {
   static process = async (
@@ -35,6 +36,7 @@ class MockProcessor {
       statusCode: responseTemplate.statusCode,
       urlParams,
       headers: request.headers as Record<string, string> || {},
+      data: getPostData(request)
     };
     
     console.log({ contextParams });

--- a/src/core/utils/templating/helpers/requestHelpers.ts
+++ b/src/core/utils/templating/helpers/requestHelpers.ts
@@ -24,6 +24,20 @@ const requestHelpers = (params: MockContextParams) => {
 
       return params.headers[param?.toLowerCase()] || defaultValue;
     },
+    body: (key: string) => { // passes key
+      const rawData = params.data
+      const defaultResponse = ''
+      if(rawData && rawData.text) {
+        try {
+          // fix-me: handle url encoded params and other operations on body later
+          const parsedData = JSON.parse(rawData.text)
+          return parsedData[key] ?? defaultResponse
+        } catch (error) {
+          /* NOOP */
+        }
+      }
+      return defaultResponse
+    }
   };
   return helpers;
 };

--- a/src/test/dummy/mock1.ts
+++ b/src/test/dummy/mock1.ts
@@ -18,7 +18,7 @@ export const dummyMock1: Mock = {
         foo: "bar",
         "content-type": "application/json",
       },
-      body: '{"Hello":"There","mockId":"1", "statusCode": {{ statusCode }}, "method": "{{ method }}", "urlParams": "{{ urlParam \'userId\' }}", "header": "{{ header \'userid\' \'test\' }}"  }}',
+      body: '{"Hello":"There","mockId":"1", "statusCode": {{ statusCode }}, "method": "{{ method }}", "urlParams": "{{ urlParam \'userId\' }}", "header": "{{ header \'userid\' \'test\' }}", body: "{{body \'test\'}}"  }',
     },
   ],
 };

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -1,3 +1,4 @@
+import { Request } from "har-format";
 import { RequestMethod } from ".";
 
 export interface MockContextParams {
@@ -5,4 +6,5 @@ export interface MockContextParams {
   method: RequestMethod;
   statusCode: number;
   headers: Record<string, string>;
+  data: Request["postData"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Templates can now access POST request body data.
  * Added a template helper: {{body 'key'}} to read values from a JSON request body.
  * If the body is missing or not valid JSON, the helper safely returns an empty string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->