### PR TITLE
chore: add Requestly ecosystem banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # requestly-mock-server
 
+> **Part of [Requestly HTTP Interceptor](https://github.com/requestly/interceptor)** · See also: [Desktop](https://github.com/requestly/http-interceptor-desktop-app) · [API Client](https://github.com/requestly/requestly) · [Docs](https://docs.requestly.com)
+
+
 This Repo contains the core express server [@requestly/mock-server](https://www.npmjs.com/package/@requestly/mock-server) package which powers Requestly's Cloud Mock Server. 
 
 ## Development


### PR DESCRIPTION
Adds the standard cross-product banner per the 2026 repo restructure. Single line, placed under the H1 title — helps visitors navigate between the API Client and HTTP Interceptor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)