### PR TITLE
chore(deps): bump handlebars from 4.7.8 to 4.7.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/har-format": "^1.2.14",
         "cors": "^2.8.5",
         "express": "^4.20.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "path-to-regexp": "^0.1.7"
       },
       "devDependencies": {
@@ -760,9 +760,10 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -2189,9 +2190,9 @@
       }
     },
     "handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/har-format": "^1.2.14",
     "cors": "^2.8.5",
     "express": "^4.20.0",
-    "handlebars": "^4.7.8",
+    "handlebars": "^4.7.9",
     "path-to-regexp": "^0.1.7"
   },
   "files": [


### PR DESCRIPTION
Bumps `handlebars` from 4.7.8 to 4.7.9 (patch release).

- Updates `package.json` and `package-lock.json`.
- No source changes required.

### Verification
- `npm install` — clean
- `npm run build` (`tsc`) — passes
- Template rendering smoke-checked (helpers: `urlParam`, `method`, `statusCode`, `header`; plain text, JSON bodies, unknown-helper escaping) — behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Handlebars package to a newer maintenance release, incorporating the latest available fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->