### PR TITLE
fix(har): guard HAR logging when a request matches no mock [RQ-2398]

### DIFF
--- a/src/middlewares/har.ts
+++ b/src/middlewares/har.ts
@@ -18,14 +18,26 @@ export const HarMiddleware = (req: Request, res: Response, next: NextFunction) =
     };
 
     res.once('finish', () => {
-        const HarEntry: Partial<Entry> = {
-            time: Date.now() - requestStartTime.getTime(),
-            startedDateTime: requestStartTimeStamp,
-            request: buildHarRequest(req),
-            response: buildHarResponse(res, { body: responseBody }),
-        }
+        try {
+            const mockId = res.locals.rq_metadata?.mockId;
+            // No matching mock (e.g. 404) means there's nothing to attach the log to.
+            if (!mockId) {
+                return;
+            }
 
-        storageService.storeLog({ mockId: res.locals.rq_metadata.mockId, HarEntry, })
+            const HarEntry: Partial<Entry> = {
+                time: Date.now() - requestStartTime.getTime(),
+                startedDateTime: requestStartTimeStamp,
+                request: buildHarRequest(req),
+                response: buildHarResponse(res, { body: responseBody }),
+            }
+
+            storageService.storeLog({ mockId, HarEntry, })
+        } catch (error) {
+            // Never let a logging failure escape the finish handler — it would
+            // surface as an uncaught exception and can crash the process.
+            console.error("[HarMiddleware] Failed to store log", error);
+        }
     });
 
     next();

--- a/src/middlewares/har.ts
+++ b/src/middlewares/har.ts
@@ -17,7 +17,7 @@ export const HarMiddleware = (req: Request, res: Response, next: NextFunction) =
         return originalSend.call(this, body);
     };
 
-    res.once('finish', () => {
+    res.once('finish', async () => {
         try {
             const mockId = res.locals.rq_metadata?.mockId;
             // No matching mock (e.g. 404) means there's nothing to attach the log to.
@@ -32,7 +32,9 @@ export const HarMiddleware = (req: Request, res: Response, next: NextFunction) =
                 response: buildHarResponse(res, { body: responseBody }),
             }
 
-            storageService.storeLog({ mockId, HarEntry, })
+            // Await so a rejected storeLog is caught here rather than surfacing
+            // as an unhandled rejection.
+            await storageService.storeLog({ mockId, HarEntry, })
         } catch (error) {
             // Never let a logging failure escape the finish handler — it would
             // surface as an uncaught exception and can crash the process.


### PR DESCRIPTION
### Problem
The HAR logging middleware registers a `res.once('finish', …)` handler that reads `res.locals.rq_metadata.mockId`. `rq_metadata` is only populated for requests that resolve to a mock — for any unmatched request (e.g. a 404), it is `undefined`, and the access throws `TypeError: Cannot read properties of undefined (reading 'mockId')`.

Because the throw happens inside the `finish` event callback (after the response is sent, outside the Express request/error pipeline), it isn't caught as a normal request error. It also means unmatched requests fail before any logging runs.

### Fix
- Access the id with optional chaining and bail out early when there is no `mockId` — an unmatched request has no mock to associate a log with.
- Wrap the handler body in try/catch so any logging error is logged and contained instead of propagating out of the event callback.

No behavior change for matched requests: they still log exactly as before.

### Testing
- `npm run build` (tsc) passes.
- Simulated the `finish` handler for both paths:
  - unmatched request (no `rq_metadata`) → no throw, logging skipped;
  - matched request → logs once with the correct `mockId` and a populated HAR entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when recording HAR logs by preventing logging errors from causing uncaught exceptions.
  * Safely handles responses without an associated mock identifier, such as 404 responses.
  * Reports failures to store HAR logs without disrupting the response lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->