### PR TITLE
[Release] v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to `@requestly/mock-server` are documented in this file.
+
+## 0.3.4 (2026-08-06)
+
+### 🐛 Bug Fixes
+
+* **har:** guard HAR logging when a request matches no mock [RQ-2398] (#40) ([f621659](https://github.com/requestly/requestly-mock-server/commit/f621659eca2d7b564d2b10139fbe8ded339db014))
+* **har:** await storeLog so async rejections are caught (#40) ([6f3f3a0](https://github.com/requestly/requestly-mock-server/commit/6f3f3a0f6837d1e91443b84018820994b5166c4d))
+
+### 🔧 Chores
+
+* **deps:** bump handlebars from 4.7.8 to 4.7.9 (#39) ([6879d11](https://github.com/requestly/requestly-mock-server/commit/6879d1146d3861944a77e993130cb00a40496ba6))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@requestly/mock-server",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@requestly/mock-server",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "ISC",
       "dependencies": {
         "@types/har-format": "^1.2.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@requestly/mock-server",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "- Methods: GET, POST, PUT, OPTIONS - Description - Endpoint (can be full path) (/api/v1/users) - Multiple Responses     - Shuffle Response     - Sequential Response     - Rules in Response - Status (Any status code 2xx, 4xx) - Latency - Body     - Templating     - Faker js - Headers",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
## Release v0.3.4

This PR bumps the release version to **v0.3.4**.

> Created manually for now, mirroring the [Release] PR that `requestly/requestly-proxy` generates via its `Create Release PR` workflow (release-it + `peter-evans/create-pull-request`). The automated process for this repo will be set up separately.

### Changes
- 📦 Version bumped in `package.json` / `package-lock.json` (0.3.3 → 0.3.4)
- 📝 `CHANGELOG.md` added with release notes
- 🔨 Package builds cleanly (`npm run build`)

### Release notes:

#### 🐛 Bug Fixes
* **har:** guard HAR logging when a request matches no mock [RQ-2398] (#40)
* **har:** await storeLog so async rejections are caught (#40)

#### 🔧 Chores
* **deps:** bump handlebars from 4.7.8 to 4.7.9 (#39)

---

### What should happen after merge?
Once the release automation is in place (matching requestly-proxy), merging this to `master` will:
1. ✅ Create git tag `v0.3.4`
2. ✅ Create GitHub release with release notes
3. ✅ Publish to npm registry as `@requestly/mock-server@0.3.4`

Until then these steps are manual — the currently published version is `0.3.3`.

---
**🚀 Ready to release? Review and merge this PR to publish!**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of HAR logging and asynchronous log storage.

* **Chores**
  * Updated the package to version 0.3.4.
  * Updated the Handlebars dependency for improved security and stability.

* **Documentation**
  * Added changelog entries describing the 0.3.4 fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->